### PR TITLE
use math/rand instead of crypto/rand.

### DIFF
--- a/client.go
+++ b/client.go
@@ -2,7 +2,7 @@ package dhcp4client
 
 import (
 	"bytes"
-	"crypto/rand"
+	"math/rand"
 	"net"
 	"time"
 


### PR DESCRIPTION
crypto/rand can take up to 5 minutes to be ready, and this is really killing our boot time on facebook OCP nodes. It needs to be working in 15 seconds from power on.