### PR TITLE
Default to math/rand in all places, add RandRead option

### DIFF
--- a/pktsock_linux.go
+++ b/pktsock_linux.go
@@ -1,8 +1,8 @@
 package dhcp4client
 
 import (
-	"crypto/rand"
 	"encoding/binary"
+	"math/rand"
 	"net"
 	"time"
 


### PR DESCRIPTION
I am aware of PR #13 and the proposed branch, but they don’t go far enough: not only the crypto/rand usage in pktsock_linux.go needs to go, but also the crypto/rand reads for generating xids.

See the commit messages for more detailed explanations, but I’d like to stress two things in the discussion of this PR:

1. this problem is made significantly worse with Linux commit https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=43838a23a05fbd13e47d750d3dfd77001536dd33 (present in Linux ≥ 4.16), which results in crypto/rand blocking on early boot until the CRNG is securely initialized. On my machine, the DHCP client would hang for minutes until sending out the first request.

2. I don’t see the need for an option on the pktconn as per the explanation in my commit message: given that the IP identifier field is only used for fragmentation, which DHCP never uses, we might as well set a static value. Using math/rand is strictly better, accepting an option to specify this behavior seems overkill to me :)

Thanks for your consideration!