### PR TITLE
Read timeout accounts for total time to receive relevant packet (2)

### DIFF
--- a/client.go
+++ b/client.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"net"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/d2g/dhcp4"
@@ -145,8 +146,15 @@ func (c *Client) SendDiscoverPacket() (dhcp4.Packet, error) {
 //Retreive Offer...
 //Wait for the offer for a specific Discovery Packet.
 func (c *Client) GetOffer(discoverPacket *dhcp4.Packet) (dhcp4.Packet, error) {
+	start := time.Now()
+
 	for {
-		c.connection.SetReadTimeout(c.timeout)
+		timeout := c.timeout - time.Since(start)
+		if timeout < 0 {
+			return dhcp4.Packet{}, syscall.ETIMEDOUT
+		}
+
+		c.connection.SetReadTimeout(timeout)
 		readBuffer, source, err := c.connection.ReadFrom()
 		if err != nil {
 			return dhcp4.Packet{}, err
@@ -186,8 +194,15 @@ func (c *Client) SendRequest(offerPacket *dhcp4.Packet) (dhcp4.Packet, error) {
 //Retreive Acknowledgement
 //Wait for the offer for a specific Request Packet.
 func (c *Client) GetAcknowledgement(requestPacket *dhcp4.Packet) (dhcp4.Packet, error) {
+	start := time.Now()
+
 	for {
-		c.connection.SetReadTimeout(c.timeout)
+		timeout := c.timeout - time.Since(start)
+		if timeout < 0 {
+			return dhcp4.Packet{}, syscall.ETIMEDOUT
+		}
+
+		c.connection.SetReadTimeout(timeout)
 		readBuffer, source, err := c.connection.ReadFrom()
 		if err != nil {
 			return dhcp4.Packet{}, err


### PR DESCRIPTION
This is #12, rebased, and with friendlier error messages as discussed in #12.