### PR TITLE
explicity request for router options

### DIFF
--- a/client.go
+++ b/client.go
@@ -289,6 +289,7 @@ func (c *Client) RequestPacket(offerPacket *dhcp4.Packet) dhcp4.Packet {
 	packet.AddOption(dhcp4.OptionDHCPMessageType, []byte{byte(dhcp4.Request)})
 	packet.AddOption(dhcp4.OptionRequestedIPAddress, (offerPacket.YIAddr()).To4())
 	packet.AddOption(dhcp4.OptionServerIdentifier, offerOptions[dhcp4.OptionServerIdentifier])
+	packet.AddOption(dhcp4.OptionParameterRequestList, []byte{byte(dhcp4.OptionRouter)})
 
 	return packet
 }


### PR DESCRIPTION
for some reason, while using Microsoft DHCP server I had to explicitly request for router options to get the gateway.