### PR TITLE
client: add support for easier custom option handling

### DIFF
--- a/client_linux_test.go
+++ b/client_linux_test.go
@@ -34,7 +34,7 @@ func Test_ExampleLinuxClient(test *testing.T) {
 
 	success := false
 
-	discoveryPacket, err := exampleClient.SendDiscoverPacket()
+	discoveryPacket, err := exampleClient.SendDiscoverPacket(nil)
 	test.Logf("Discovery:%v\n", discoveryPacket)
 
 	if err != nil {
@@ -55,7 +55,7 @@ func Test_ExampleLinuxClient(test *testing.T) {
 		test.Fatalf("Offer Error:%v\n", err)
 	}
 
-	requestPacket, err := exampleClient.SendRequest(&offerPacket)
+	requestPacket, err := exampleClient.SendRequest(&offerPacket, nil)
 	if err != nil {
 		test.Fatalf("Send Offer Error:%v\n", err)
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -31,7 +31,7 @@ func Test_ExampleClient(test *testing.T) {
 	}
 	defer exampleClient.Close()
 
-	success, acknowledgementpacket, err := exampleClient.Request()
+	success, acknowledgementpacket, err := exampleClient.Request(nil)
 
 	test.Logf("Success:%v\n", success)
 	test.Logf("Packet:%v\n", acknowledgementpacket)
@@ -52,7 +52,7 @@ func Test_ExampleClient(test *testing.T) {
 	}
 
 	test.Log("Start Renewing Lease")
-	success, acknowledgementpacket, err = exampleClient.Renew(acknowledgementpacket)
+	success, acknowledgementpacket, err = exampleClient.Renew(acknowledgementpacket, nil)
 	if err != nil {
 		networkError, ok := err.(*net.OpError)
 		if ok && networkError.Timeout() {
@@ -94,7 +94,7 @@ func Test_ExampleClientWithMathGenerateXID(test *testing.T) {
 	}
 	defer exampleClient.Close()
 
-	success, acknowledgementpacket, err := exampleClient.Request()
+	success, acknowledgementpacket, err := exampleClient.Request(nil)
 
 	test.Logf("Success:%v\n", success)
 	test.Logf("Packet:%v\n", acknowledgementpacket)


### PR DESCRIPTION
client: add support for easier custom option handling

Allow callers to pass arbitrary options to the various packet
creation functions.  The full Request() will pass the same set of
options to the discover and request packets.

```
    options := dhcp4.Options{
            dhcp4.OptionClientIdentifier: clientID,
            dhcp4.dhcp4.OptionParameterRequestList: []byte{byte(dhcp4.OptionRouter)},
    }
    discovery := client.DiscoverPacket(options)
```
or
```
    options := dhcp4.Options{
            dhcp4.OptionClientIdentifier: clientID,
            dhcp4.dhcp4.OptionParameterRequestList: []byte{byte(dhcp4.OptionRouter)},
    }
    ok, ack, err := c.Request(options)
```
Fixes: https://github.com/d2g/dhcp4client/issues/22
Fixes: https://github.com/d2g/dhcp4client/pull/23

@d2g @mccv1r0