### PR TITLE
add permit servers

### DIFF
--- a/client_acknowledgement.go
+++ b/client_acknowledgement.go
@@ -43,7 +43,7 @@ func (c *Client) GetAcknowledgementWithOptions(requestPacket *dhcp4.Packet, opts
 
 		// Ignore Servers in my Ignore list
 		//BUG(d2g): Should Use the Server Identifier Option
-		if c.ignoreServer([]net.IP{source.IP}) {
+		if !c.tolerateServer([]net.IP{source.IP}) {
 			continue
 		}
 

--- a/client_offer.go
+++ b/client_offer.go
@@ -47,8 +47,7 @@ func (c *Client) GetOfferWithOptions(xid []byte, opts DHCP4ClientOptions) (dhcp4
 		offerPacket := dhcp4.Packet(readBuffer)
 		offerPacketOptions := offerPacket.ParseOptions()
 
-		// Ignore Servers in my Ignore list
-		if c.ignoreServer([]net.IP{offerPacketOptions[dhcp4.OptionServerIdentifier]}) {
+		if !c.tolerateServer([]net.IP{offerPacketOptions[dhcp4.OptionServerIdentifier]}) {
 			continue
 		}
 


### PR DESCRIPTION
Signed-off-by: zhangjie <iamkadisi@163.com>

add permitServers 

allow client to accept only a few specific server response.